### PR TITLE
fix saving `__v` into `refVersion`

### DIFF
--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -12,6 +12,7 @@ module.exports = function (schema, mongoose) {
 
           clonedPath[key] = path.options;
           clonedPath[key].unique = false;
+          clonedPath[key].index = false;
 
           clonedSchema.add(clonedPath);
         }

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -7,12 +7,14 @@ module.exports = function (schema, mongoose) {
     var clonedSchema = new mongoose.Schema();
 
     schema.eachPath(function (key, path) {
-        var clonedPath = {};
+        if (key !== '_id') {
+          var clonedPath = {};
 
-        clonedPath[key] = path.options;
-        clonedPath[key].unique = false;
+          clonedPath[key] = path.options;
+          clonedPath[key].unique = false;
 
-        clonedSchema.add(clonedPath);
+          clonedSchema.add(clonedPath);
+        }
     });
 
     return clonedSchema;

--- a/lib/save-collection.js
+++ b/lib/save-collection.js
@@ -15,9 +15,17 @@ module.exports = function (schema, options) {
     setSchemaOptions(versionedSchema, options);
 
     versionedSchema.add({
-        refId: ObjectId,
-        refVersion: Number
+        refId: {
+          type: ObjectId,
+          index: true
+        },
+        refVersion: {
+          type: Number,
+          index: true
+        }
     });
+
+    versionedSchema.index({ refId:1, refVersion:1 });
 
     // Add reference to model to original schema
     schema.statics.VersionedModel = {};

--- a/lib/save-collection.js
+++ b/lib/save-collection.js
@@ -4,7 +4,8 @@
 var debug = require('debug')('mongoose:version'),
     xtend = require('xtend'),
     cloneSchema = require('./clone-schema'),
-    setSchemaOptions = require('./set-schema-options');
+    setSchemaOptions = require('./set-schema-options'),
+    VersionError = require('mongoose/lib/error/version');
 
 module.exports = function (schema, options) {
     var versionedSchema = cloneSchema(schema, options.mongoose),
@@ -31,9 +32,31 @@ module.exports = function (schema, options) {
 
     schema.pre('save', function (next) {
         if (!options.suppressVersionIncrement) {
-            this.increment(); // Increment origins version
-        }
+            var self = this;
+            self.increment(); // Increment origins version
 
+            // Checks for version conflict
+            schema.statics.VersionedModel.find({
+                refId: self._id,
+                refVersion: { $exists: true } // keep it backwards compatible
+            })
+            .sort({ refVersion: -1 })
+            .limit(1)
+            .exec(function(err, docs){
+                if (docs.length !== 0 && docs[0].refVersion > (self._doc[schema.options.versionKey] || 0)) {
+                  var err = new VersionError();
+                  debug(err);
+                  return next(err);
+                }
+
+                createVersion.call(self, next);
+            });
+        } else {
+            createVersion.call(this, next);
+        }
+    });
+
+    function createVersion(next){
         var clone = xtend(this._doc);
 
         delete clone._id;
@@ -50,7 +73,27 @@ module.exports = function (schema, options) {
 
             next();
         });
-    });
+    }
+
+    // schema.post('save', function (doc) {
+    //     console.log('called');
+    //     var clone = xtend(doc);
+    //
+    //     delete clone._id;
+    //     // Saves current document version, first time to 0
+    //     clone.refVersion = typeof doc[schema.options.versionKey] === 'undefined' ? 0 : doc[schema.options.versionKey] + 1; // we are in the prehook so need to increment
+    //     clone.refId = doc._id; // Sets origins document id as a reference
+    //
+    //     new schema.statics.VersionedModel(clone).save(function (err) {
+    //         if (err) {
+    //             debug(err);
+    //         } else {
+    //             debug('Created versioned model in mongodb');
+    //         }
+    //
+    //         // next();
+    //     });
+    // })
 
     schema.pre('remove', function (next) {
         if (!options.removeVersions) {

--- a/lib/save-collection.js
+++ b/lib/save-collection.js
@@ -31,9 +31,15 @@ module.exports = function (schema, options) {
     schema.statics.VersionedModel = {};
 
     schema.on('init', function (Model) {
-        // Add reference to model to original schema
         var VersionedModel = Model.db.model(options.collection, versionedSchema);
+        VersionedModel.ensureIndexes(function (err) {
+          if (err) debug('ENSURE INDEX', err)
+        });
+        VersionedModel.on('index', function (err) {
+          if (err) debug('INDEX', err)
+        });
 
+        // Add reference to model to original schema
         schema.statics.VersionedModel = VersionedModel;
         Model.VersionedModel = VersionedModel;
     });

--- a/lib/save-collection.js
+++ b/lib/save-collection.js
@@ -31,13 +31,14 @@ module.exports = function (schema, options) {
 
     schema.pre('save', function (next) {
         if (!options.suppressVersionIncrement) {
-            this.increment(); // Increment origins version    
+            this.increment(); // Increment origins version
         }
 
         var clone = xtend(this._doc);
 
         delete clone._id;
-        clone.refVersion = this._doc.__v; // Saves current document version
+        // Saves current document version, first time to 0
+        clone.refVersion = typeof this._doc[schema.options.versionKey] === 'undefined' ? 0 : this._doc[schema.options.versionKey] + 1; // we are in the prehook so need to increment
         clone.refId = this._id; // Sets origins document id as a reference
 
         new schema.statics.VersionedModel(clone).save(function (err) {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,12 @@
 {
-  "name": "lackey-mongoose-version",
+  "name": "@streethub/mongoose-version",
   "description": "Mongoose plugin to save old versions of saved documents",
   "version": "1.1.0",
   "main": "lib/version.js",
-  "repository": "git://github.com/getlackey/mongoose-version.git",
-  "author": "Enigma Marketing",
-  "contributors": [
-    {
-      "name": "Christoph Walcher",
-      "email": "christoph.walcher@gmail.com",
-      "description": "Author of the forked plugin https://github.com/saintedlama/mongoose-version"
-    }
-  ],
-  "license": "BSD",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/StreetHub/mongoose-version.git"
+  },
   "keywords": [
     "mongoose",
     "plugin",
@@ -33,5 +27,13 @@
   "scripts": {
     "test": "mocha --recursive -R spec test/",
     "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --recursive -- -R spec"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/StreetHub/mongoose-version/issues"
+  },
+  "homepage": "https://github.com/StreetHub/mongoose-version#readme",
+  "directories": {
+    "test": "test"
+  },
+  "author": ""
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lackey-mongoose-version",
     "description": "Mongoose plugin to save old versions of saved documents",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "lib/version.js",
     "repository": "git://github.com/getlackey/mongoose-version.git",
     "author": "Enigma Marketing",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,37 @@
 {
-    "name": "lackey-mongoose-version",
-    "description": "Mongoose plugin to save old versions of saved documents",
-    "version": "1.0.4",
-    "main": "lib/version.js",
-    "repository": "git://github.com/getlackey/mongoose-version.git",
-    "author": "Enigma Marketing",
-    "contributors": [{
-        "name": "Christoph Walcher",
-        "email": "christoph.walcher@gmail.com",
-        "description": "Author of the forked plugin https://github.com/saintedlama/mongoose-version"
-    }],
-    "license": "BSD",
-    "keywords": [
-        "mongoose",
-        "plugin",
-        "version"
-    ],
-    "dependencies": {
-        "debug": "~0.8.1",
-        "xtend": "^4.0.0"
-    },
-    "devDependencies": {
-        "bluebird": "^3.3.1",
-        "chai": "~1.9.1",
-        "istanbul": "^0.3.2",
-        "mocha": "~1.20.0",
-        "mongoose-text-search": "0.0.2",
-        "mongoose": "~3.8.12"
-    },
-    "scripts": {
-        "test": "mocha --recursive -R spec test/",
-        "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --recursive -- -R spec"
+  "name": "lackey-mongoose-version",
+  "description": "Mongoose plugin to save old versions of saved documents",
+  "version": "1.0.5",
+  "main": "lib/version.js",
+  "repository": "git://github.com/getlackey/mongoose-version.git",
+  "author": "Enigma Marketing",
+  "contributors": [
+    {
+      "name": "Christoph Walcher",
+      "email": "christoph.walcher@gmail.com",
+      "description": "Author of the forked plugin https://github.com/saintedlama/mongoose-version"
     }
+  ],
+  "license": "BSD",
+  "keywords": [
+    "mongoose",
+    "plugin",
+    "version"
+  ],
+  "dependencies": {
+    "debug": "~0.8.1",
+    "xtend": "^4.0.0"
+  },
+  "devDependencies": {
+    "bluebird": "^3.3.1",
+    "chai": "~1.9.1",
+    "istanbul": "^0.3.2",
+    "mocha": "~1.20.0",
+    "mongoose-text-search": "0.0.2",
+    "mongoose": "~3.8.12"
+  },
+  "scripts": {
+    "test": "mocha --recursive -R spec test/",
+    "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --recursive -- -R spec"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lackey-mongoose-version",
   "description": "Mongoose plugin to save old versions of saved documents",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "main": "lib/version.js",
   "repository": "git://github.com/getlackey/mongoose-version.git",
   "author": "Enigma Marketing",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lackey-mongoose-version",
     "description": "Mongoose plugin to save old versions of saved documents",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "main": "lib/version.js",
     "repository": "git://github.com/getlackey/mongoose-version.git",
     "author": "Enigma Marketing",
@@ -21,6 +21,7 @@
         "xtend": "^4.0.0"
     },
     "devDependencies": {
+        "bluebird": "^3.3.1",
         "chai": "~1.9.1",
         "istanbul": "^0.3.2",
         "mocha": "~1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@streethub/mongoose-version",
   "description": "Mongoose plugin to save old versions of saved documents",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/version.js",
   "repository": {
     "type": "git",

--- a/test/multiple-db-connections/version.js
+++ b/test/multiple-db-connections/version.js
@@ -7,7 +7,8 @@ var expect = require('chai').expect,
     mongoose = Bluebird.promisifyAll(require('mongoose')),
     Schema = mongoose.Schema,
     mongotest = require('./mongotest'),
-    version = require('../../lib/version');
+    version = require('../../lib/version'),
+    VersionError = require('mongoose/lib/error/version');
 
 describe('version', function () {
     beforeEach(mongotest.prepareDb('mongodb://localhost/mongoose_version_tests'));
@@ -60,6 +61,82 @@ describe('version', function () {
                 done();
             });
         });
+    });
+
+    it('should NOT save a version model when saving origin model fails', function (done) {
+        var testSchema = new Schema({
+                name: String
+            }),
+            Test,
+            test;
+
+        testSchema.plugin(version, {
+            collection: 'should_save_version_of_origin_model_versions',
+            suppressVersionIncrement: false // let's increment the version on updates
+        });
+
+        Test = mongotest.connection.model('should_save_version_of_origin_model', testSchema);
+
+        test = new Test({
+            name: 'franz'
+        });
+
+        test.saveAsync()
+        .then(function (doc) {
+            expect(doc).to.have.a.property('__v', 0);
+        })
+        .then(function(){
+            return Test.VersionedModel.findAsync({
+                refId: test._id,
+            })
+            .then(function (versionedModels) {
+                expect(versionedModels).to.have.a.lengthOf(1);
+                expect(versionedModels[0]).to.be.ok;
+                expect(versionedModels[0]).to.have.a.property('name', 'franz');
+                expect(versionedModels[0]).to.have.a.property('refVersion', 0);
+            });
+        })
+        .then(function () {
+            test.name = 'Franz I';
+            test.__v = 0;
+            return test.saveAsync()
+            .then(function (doc) {
+                expect(doc).to.have.a.property('__v', 1);
+            });
+        })
+        .then(function () {
+            return Test.VersionedModel.findAsync({
+                refId: test._id
+            })
+            .then(function (versionedModels) {
+                expect(versionedModels).to.have.a.lengthOf(2);
+                expect(versionedModels[0]).to.be.ok;
+                expect(versionedModels[0]).to.have.a.property('name', 'franz');
+                expect(versionedModels[0]).to.have.a.property('refVersion', 0);
+                expect(versionedModels[1]).to.be.ok;
+                expect(versionedModels[1]).to.have.a.property('name', 'Franz I');
+                expect(versionedModels[1]).to.have.a.property('refVersion', 1);
+            });
+        })
+        .then(function () {
+            test.name = 'Franz Invalid';
+            test.__v = 0; // create a version conflict
+            return test.saveAsync()
+            .then(function(){ expect(false).to.be.ok; }) // should not happen
+            .catch(VersionError, function(err){
+                expect(err.name).to.eql('VersionError');
+            });
+        })
+        .then(function () {
+            return Test.VersionedModel.findAsync({
+                refId: test._id
+            })
+            .then(function (versionedModels) {
+                expect(versionedModels).to.have.a.lengthOf(2);
+            });
+        })
+        .then(done.bind(this, null))
+        .catch(done);
     });
 
     it('should save the correct version, defined at the versionKey of the origin model', function (done) {


### PR DESCRIPTION
This pull fixes saving the version of the versioned document. Plus adds the ability to do that with a non-default `versionKey`.
Tests added. Please let me know if you need any updates.
