### PR TITLE
[RFC]: upgraded mongoose to ^4.7.3 and fixed the unit tests

### DIFF
--- a/lib/save-collection.js
+++ b/lib/save-collection.js
@@ -58,7 +58,7 @@ module.exports = function (schema, options) {
             .limit(1)
             .exec(function(err, docs){
                 if (docs.length !== 0 && docs[0].refVersion > (self._doc[schema.options.versionKey] || 0)) {
-                  var err = new VersionError();
+                  var err = new VersionError(self);
                   debug(err);
                   return next(err);
                 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "istanbul": "^0.3.2",
     "mocha": "~1.20.0",
     "mongoose-text-search": "0.0.2",
-    "mongoose": "~3.8.12"
+    "mongoose": "~4.7.3"
   },
   "scripts": {
     "test": "mocha --recursive -R spec test/",


### PR DESCRIPTION
Upgraded mongoose to version 4.7.3 to be compatible with mongo 3.4. This broke one unit test, because the code wasn't using the Version function properly; so it fixes this.